### PR TITLE
Update info/1 directives for the preferred format for versions and dates in Logtalk 3.36.0

### DIFF
--- a/actor.lgt
+++ b/actor.lgt
@@ -1,8 +1,8 @@
 :- category(actor).
 
-    :- info([ version is 1.4
+    :- info([ version is 1:4:0
             , author is 'Paul Brown'
-            , date is 2019/11/23
+            , date is 2019-11-23
             , comment is 'An category for actors: those who can do actions.'
             ]).
 

--- a/bedsit.lgt
+++ b/bedsit.lgt
@@ -1,8 +1,8 @@
 :- object(bedsit).
 
-    :- info([ version is 1.4
+    :- info([ version is 1:4:0
             , author is 'Paul Brown'
-            , date is 2019/11/23
+            , date is 2019-11-23
             , comment is 'The core of bedsit: gatekeeper for a situation term.'
             ]).
 

--- a/fluent_predicates.lgt
+++ b/fluent_predicates.lgt
@@ -1,8 +1,8 @@
 :- category(fluent_predicates).
 
-    :- info([ version is 1.4
+    :- info([ version is 1:4:0
             , author is 'Paul Brown'
-            , date is 2019/11/23
+            , date is 2019-11-23
             , comment is 'An category for objects with fluent predicates.'
             ]).
 

--- a/persistence.lgt
+++ b/persistence.lgt
@@ -1,9 +1,9 @@
 :- object(persistence(_File_),
     implements(monitoring)).
 
-    :- info([ version is 1.4
+    :- info([ version is 1:4:0
             , author is 'Paul Brown'
-            , date is 2019/11/23
+            , date is 2019-11-23
             , comment is 'An observer of some situation manager that persists updates to the situation.'
             ]).
 

--- a/view_category.lgt
+++ b/view_category.lgt
@@ -1,9 +1,9 @@
 :- category(view_category,
     implements(monitoring)).
 
-    :- info([ version is 1.1
+    :- info([ version is 1:1:0
             , author is 'Paul Brown'
-            , date is 2019/11/23
+            , date is 2019-11-23
             , comment is 'A parent class for views that are sent the situation to render'
             ]).
 


### PR DESCRIPTION
Note that this pull request makes Logtalk 3.36.0 or later required